### PR TITLE
Fix: Disable GitHub Pages deployment and use Railway instead

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,7 +22,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     
-    # Tạo package-lock.json nếu cần
     - name: Create package-lock.json if needed
       run: |
         if [ ! -f package-lock.json ]; then
@@ -64,22 +63,24 @@ jobs:
         path: dist/
         retention-days: 1
 
-  deploy:
-    needs: build
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
-    
-    steps:
-    - uses: actions/checkout@v4
-    
-    - name: Download built files
-      uses: actions/download-artifact@v4
-      with:
-        name: build-files
-        path: dist/
-    
-    - name: Deploy to GitHub Pages
-      uses: JamesIves/github-pages-deploy-action@v4.5.0
-      with:
-        branch: gh-pages
-        folder: dist
+  # Job deploy được comment out để tắt GitHub Pages deployment
+  # Đã triển khai trên Railway thay thế
+  # deploy:
+  #   needs: build
+  #   if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+  #   runs-on: ubuntu-latest
+  #   
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   
+  #   - name: Download built files
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: build-files
+  #       path: dist/
+  #   
+  #   - name: Deploy to GitHub Pages
+  #     uses: JamesIves/github-pages-deploy-action@v4.5.0
+  #     with:
+  #       branch: gh-pages
+  #       folder: dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Tất cả những thay đổi đáng chú ý của dự án sẽ được ghi lại ở đây.
 
+## [1.0.2] - 2025-04-11
+
+### Sửa lỗi
+- Cập nhật URL demo để sử dụng Railway deployment
+- Sửa cấu hình GitHub Actions để triển khai chính xác
+
 ## [1.0.1] - 2025-04-11
 
 ### Sửa lỗi

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # React Playground
 
 ![CI/CD](https://img.shields.io/github/actions/workflow/status/Phune23/react-playground/ci-cd.yml?branch=main&label=CI%2FCD)
-![Version](https://img.shields.io/badge/version-1.0.1-blue.svg)
+![Version](https://img.shields.io/badge/version-1.0.2-blue.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![Node](https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen)
+![Railway](https://img.shields.io/badge/Railway-Deployed-success)
 
 Ứng dụng playground cho React, giúp học và thực hành React một cách trực quan.
 
@@ -19,7 +20,7 @@
 
 ## Demo
 
-[Live Demo](https://your-username.github.io/react-playground/)
+[Live Demo](https://react-playground-production.up.railway.app/)
 
 ## Yêu cầu hệ thống
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-playground",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## Thay đổi

- Tắt GitHub Pages deployment trong CI/CD workflow vì đã sử dụng Railway
- Cập nhật README với badge Railway
- Cập nhật version lên 1.0.2 trong package.json

## Lý do

GitHub Pages deployment gặp lỗi quyền truy cập, nhưng vì đã triển khai thành công trên Railway nên quyết định sử dụng Railway làm nền tảng hosting chính thức.